### PR TITLE
added 'require openssl' due to error being thrown

### DIFF
--- a/nessus6-report-downloader.rb
+++ b/nessus6-report-downloader.rb
@@ -29,6 +29,7 @@ require 'fileutils'
 require 'io/console'
 require 'date'
 require 'json'
+require 'openssl'
 
 # This method will download the specified file type from specified reports
 def report_download(http, headers, reports, reports_to_dl, filetypes_to_dl, chapters_to_dl, rpath, db_export_pw)


### PR DESCRIPTION
Hi eelsivart,

Script was spitting out following error:
"""
Enter the Nessus Server IP: 192.168.1.2
Enter the Nessus Server Port [8834]: 
nessus6-report-downloader.rb:162:in `<main>': uninitialized constant OpenSSL (NameError)
"""

Issue was resolved by explicitly requiring openssl lib

Tested Using:
rvm 1.29.1 (latest) 
ruby-2.2.3 [ x86_64 ]
ruby-2.4.0 [ x86_64 ]
ruby-2.4.1 [ x86_64 ]